### PR TITLE
Add Header and Layout

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+const linkStyle = {
+   marginRight: 15
+};
+
+const Header = () => (
+   <div>
+      <Link href="/">
+         <a style={linkStyle}>Home</a>
+      </Link>
+      <Link href="/about">
+         <a style={linkStyle}>About</a>
+      </Link>
+   </div>
+);
+
+export default Header;

--- a/layouts/index.js
+++ b/layouts/index.js
@@ -1,0 +1,16 @@
+import Header from "../components/Header";
+
+const layoutStyle = {
+   margin: 20,
+   padding: 20,
+   border: "1px solid #DDD"
+};
+
+const DefaultLayout = props => (
+   <div style={layoutStyle}>
+      <Header />
+      {props.children}
+   </div>
+);
+
+export default DefaultLayout;

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,7 +1,9 @@
+import Layout from "../layouts";
+
 const About = () => (
-   <div>
+   <Layout>
       <p>About Page</p>
-   </div>
+   </Layout>
 );
 
 export default About;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,10 @@
 import Link from "next/link";
+import Layout from "../layouts";
 
 const Index = () => (
-   <div>
-      <Link href="/about">
-         <button style={{ fontSize: 20 }}>About</button>
-      </Link>
+   <Layout>
       <p>Hello Next.js</p>
-   </div>
+   </Layout>
 );
 
 export default Index;


### PR DESCRIPTION
Created `components/` in line with the tutorial. This is a pretty standard practice for organizing shared components.

Created `layouts/` for organizing layout type components. The tutorial walks you through putting layouts under components, but I prefer this approach. It makes it a bit easier to differentiate based on import statements what the components actually do. I created the default layout in `index.js`, expecting that new layouts would be created in separate files and/or dirs, and exported from `index.js`.

In hindsight, `Header` probably belongs in `layouts/`, along with other layout specific components, like footers, sidebars, and vertical sections.